### PR TITLE
CRC the frame buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cortex-m-log = {  version = "0.4.0", features = ["itm", "log-integration"] }
 log = "0.4.6"
 
 [dependencies.ssd1351]
-version = "0.2.0"
+version = "0.2.1"
 # git = "https://github.com/mabezdev/ssd1351"
 # rev = "716af2c8de8b24c22d489df7a10ecbd62349fee5"
 # path = "../../drivers/ssd1351"


### PR DESCRIPTION
use new ssd1351 to crc the frame buffer to reduce unecessary writes to the display. Reduced systick to compensate for this extra load. It may be better to separate rendering from the logic thread, this could also allow for spi dma transfers?