### PR TITLE
move system into kernel core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,8 +25,17 @@ checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
 dependencies = [
  "generic-array 0.12.4",
  "generic-array 0.13.3",
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -37,9 +46,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "az"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "bare-metal"
@@ -104,15 +113,15 @@ dependencies = [
  "aligned 0.3.5",
  "bare-metal",
  "bitfield",
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
  "volatile-register",
 ]
 
 [[package]]
 name = "cortex-m"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
+checksum = "70858629a458fdfd39f9675c4dc309411f2a3f83bede76988d81bf1a0ecee9e0"
 dependencies = [
  "bare-metal",
  "bitfield",
@@ -161,7 +170,7 @@ dependencies = [
  "cortex-m-rtic-macros",
  "heapless 0.6.1",
  "rtic-core",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -182,7 +191,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bffa6c1454368a6aa4811ae60964c38e6996d397ff8095a8b9211b1c1f749bc"
 dependencies = [
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
 ]
 
 [[package]]
@@ -195,14 +204,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-graphics"
-version = "0.4.9"
+name = "critical-section"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7ee289ac88cbeea6f749cd72c6eb4cdeb801f4ea26795aace97b9776a2db2"
-dependencies = [
- "tinybmp",
- "tinytga",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "embedded-graphics"
@@ -275,12 +280,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -293,10 +298,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
+name = "hash32"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heapless"
@@ -306,7 +320,7 @@ checksum = "e1ae80bbc62401ae8096976857172507cadbd2200f36670e5144634360a05959"
 dependencies = [
  "as-slice",
  "generic-array 0.11.2",
- "hash32",
+ "hash32 0.1.1",
 ]
 
 [[package]]
@@ -316,8 +330,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
  "as-slice",
- "generic-array 0.14.5",
- "hash32",
+ "generic-array 0.14.6",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version 0.4.0",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -334,19 +361,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.126"
+name = "lock_api"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -367,12 +398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "micromath"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,9 +413,9 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "crc",
- "embedded-graphics 0.7.1",
+ "embedded-graphics",
  "embedded-hal",
- "heapless 0.4.4",
+ "heapless 0.7.16",
  "hm11",
  "log",
  "max17048",
@@ -400,7 +425,7 @@ dependencies = [
  "panic-semihosting",
  "rtt-target",
  "simple-hex",
- "ssd1351 0.4.1",
+ "ssd1351",
  "stm32l4xx-hal",
  "time",
 ]
@@ -410,12 +435,11 @@ name = "mwatch_kernel"
 version = "2.0.0"
 dependencies = [
  "crc",
- "embedded-graphics 0.7.1",
+ "embedded-graphics",
  "embedded-hal",
- "heapless 0.4.4",
+ "heapless 0.7.16",
  "log",
  "simple-hex",
- "ssd1351 0.3.0",
  "time",
 ]
 
@@ -435,26 +459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check 0.9.4",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,21 +468,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "panic-itm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d577d97d1b31268087b6dddf2470e6794ef5eee87d9dca7fcd0481695391a4c"
 dependencies = [
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
 ]
 
 [[package]]
@@ -487,7 +482,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ab67bc881453e4c90f958c657c1303670ea87bc1a16e87fd71a40f656dce9"
 dependencies = [
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
  "rtt-target",
 ]
 
@@ -497,24 +492,24 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
 dependencies = [
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
  "cortex-m-semihosting",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -548,7 +543,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
 dependencies = [
- "cortex-m 0.7.5",
+ "cortex-m 0.7.6",
  "ufmt-write",
 ]
 
@@ -567,8 +562,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.9",
+ "semver 1.0.16",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -581,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
@@ -598,19 +599,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b581d48c218869658cf5e61f33835dd69ef4722e1cad6f43157afa9f72c2d46e"
 
 [[package]]
-name = "ssd1351"
-version = "0.3.0"
-source = "git+https://github.com/mabezdev/ssd1351?rev=6240d8cc614a0d10cfb067faf1b87968369c4b56#6240d8cc614a0d10cfb067faf1b87968369c4b56"
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
- "embedded-graphics 0.4.9",
- "embedded-hal",
+ "lock_api",
 ]
 
 [[package]]
 name = "ssd1351"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb81a95aa3c4961c29f1151ab2a75156c3fa217623aea0f74a4c8d64f4c3747"
+checksum = "791086e9ee362d1c22c7fc1b59aaf78500ed72f4b4fad1942d72d89815aff143"
 dependencies = [
  "embedded-graphics-core",
  "embedded-hal",
@@ -652,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -663,37 +664,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "libc",
- "num_threads",
+ "time-core",
 ]
 
 [[package]]
-name = "tinybmp"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d12b7f8b271567d6d072c49dee16b22271aabfc473e2066e3353e5af0f5230"
-dependencies = [
- "nom 5.1.2",
-]
-
-[[package]]
-name = "tinytga"
+name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9485052c1f4b541d888f1d564dd9957671e0c21da9bca0c9824c1123e03f07"
-dependencies = [
- "nom 4.2.3",
-]
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ufmt-write"
@@ -703,21 +691,15 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/kernel/src/application/display_manager.rs
+++ b/kernel/src/application/display_manager.rs
@@ -12,7 +12,7 @@ use crate::{application::{
         notifications::NotificationState,
     },
     states::prelude::*
-}, system::{input::InputEvent, System, Display}};
+}, system::{input::InputEvent, System, Display, Host}};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Signal {
@@ -58,7 +58,7 @@ impl DisplayManager
 {
 
     /// Services the current application
-    pub fn process(&mut self, system: &mut impl System, display: &mut impl Display) {
+    pub fn process(&mut self, system: &mut System<impl Host>, display: &mut impl Display) {
         let signal = match self.state_idx {
             0 => {
                 DisplayManager::static_state_render(&mut self.clock_state, system, display)
@@ -87,7 +87,7 @@ impl DisplayManager
     }
 
     /// Services input to the current application
-    pub fn service_input(&mut self, system: &mut impl System, input: InputEvent) {
+    pub fn service_input(&mut self, system: &mut System<impl Host>, input: InputEvent) {
         let signal = match self.state_idx {
             0 => {
                 DisplayManager::static_state_input(&mut self.clock_state, system, input)
@@ -141,7 +141,7 @@ impl DisplayManager
     }
 
     /// Render a static state
-    fn static_state_render<S>(state: &mut S, system: &mut impl System, display: &mut impl Display) -> Option<Signal> 
+    fn static_state_render<S>(state: &mut S, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> 
         where S : StaticState
     {
         state.render(system, display)
@@ -149,7 +149,7 @@ impl DisplayManager
 
     /// Render a scoped state, this state may or may not be running hence we have different functionality
     /// depending on the `is_running()` state
-    fn scoped_state_render<S>(state: &mut S, system: &mut impl System, display: &mut impl Display) -> Option<Signal> 
+    fn scoped_state_render<S>(state: &mut S, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> 
         where S : ScopedState
     {
         if state.is_running(system) {
@@ -160,7 +160,7 @@ impl DisplayManager
     }
 
     /// Handle input for a static state
-    fn static_state_input<S>(state: &mut S, system: &mut impl System, input: InputEvent) -> Option<Signal> 
+    fn static_state_input<S>(state: &mut S, system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> 
         where S : StaticState
     {
         state.input(system, input)
@@ -168,7 +168,7 @@ impl DisplayManager
 
     /// Handle the input for a scoped state, this state may or may not be running hence we have different functionality
     /// depending on the `is_running()` state
-    fn scoped_state_input<S>(state: &mut S, system: &mut impl System, input: InputEvent) -> Option<Signal> 
+    fn scoped_state_input<S>(state: &mut S, system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> 
         where S : ScopedState
     {
         if state.is_running(system) {

--- a/kernel/src/application/states/app.rs
+++ b/kernel/src/application/states/app.rs
@@ -4,6 +4,7 @@
 //!  
 
 use crate::application::states::prelude::*;
+use crate::system::Host;
 use crate::system::input::InputEvent;
 use crate::system::Display;
 use crate::system::System;
@@ -27,21 +28,21 @@ impl Default for AppState {
 }
 
 impl State for AppState {
-    fn render(&mut self, system: &mut impl System, display: &mut impl Display) -> Option<Signal> {
-        system.am().service(display).unwrap_or_else(|err| {
+    fn render(&mut self, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> {
+        system.am.service(display).unwrap_or_else(|err| {
             error!("Failed to render app {:?}", err);
         });
         None
     }
 
-    fn input(&mut self, system: &mut impl System, input: InputEvent) -> Option<Signal> {
+    fn input(&mut self, system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> {
         match input {
             InputEvent::Multi => {
-                system.am().pause();
+                system.am.pause();
                 Some(Signal::Home) // signal to dm to go home
             }
             _ => {
-                system.am().service_input(input).unwrap_or_else(|err| {
+                system.am.service_input(input).unwrap_or_else(|err| {
                     error!("Failed to service input for app {:?}", err);
                 });
                 None
@@ -52,9 +53,9 @@ impl State for AppState {
 
 impl ScopedState for AppState {
     /// Render a preview or Icon before launching the whole application
-    fn preview(&mut self, system: &mut impl System, display: &mut impl Display) -> Option<Signal> {
+    fn preview(&mut self, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> {
         self.buffer.clear();
-        let status = system.am().status();
+        let status = system.am.status();
         if status.is_loaded {
             write!(self.buffer, "Open loaded App").unwrap();
         } else {
@@ -68,21 +69,21 @@ impl ScopedState for AppState {
         None
     }
 
-    fn is_running(&self, system: &mut impl System) -> bool {
-        system.am().status().is_running
+    fn is_running(&self, system: &mut System<impl Host>) -> bool {
+        system.am.status().is_running
     }
 
     /// Start
-    fn start(&mut self, system: &mut impl System) {
-        match system.am().execute() {
+    fn start(&mut self, system: &mut System<impl Host>) {
+        match system.am.execute() {
             Ok(_) => {}
             Err(err) => error!("Failed to launch application {:?}", err),
         }
     }
 
     /// Stop
-    fn stop(&mut self, system: &mut impl System) {
-        system.am().kill().unwrap_or_else(|err| {
+    fn stop(&mut self, system: &mut System<impl Host>) {
+        system.am.kill().unwrap_or_else(|err| {
             error!("Failed to kill app {:?}", err);
         });
     }

--- a/kernel/src/application/states/info.rs
+++ b/kernel/src/application/states/info.rs
@@ -2,6 +2,8 @@
 
 use crate::application::states::prelude::*;
 use crate::system::Display;
+use crate::system::Host;
+use crate::system::Statistics;
 use crate::system::System;
 use crate::system::input::InputEvent;
 use embedded_graphics::mono_font::MonoTextStyle;
@@ -20,10 +22,10 @@ impl Default for InfoState {
 }
 
 impl State for InfoState {
-    fn render(&mut self, system: &mut impl System, display: &mut impl Display) -> Option<Signal> {
+    fn render(&mut self, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> {
         let style = MonoTextStyle::new(&FONT_6X12, RawU16::new(0x02D4).into());
 
-        for (i, buffer) in system.stats().enumerate() {
+        for (i, buffer) in system.stats.stats().enumerate() {
             Text::with_baseline(
                 &buffer,
                 Point::new(0, (i as i32 * 12) + 2),
@@ -36,7 +38,7 @@ impl State for InfoState {
         None
     }
 
-    fn input(&mut self, _system: &mut impl System, input: InputEvent) -> Option<Signal> {
+    fn input(&mut self, _system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> {
         match input {
             InputEvent::Left => Some(Signal::Previous),
             InputEvent::Right => Some(Signal::Next),

--- a/kernel/src/application/states/mod.rs
+++ b/kernel/src/application/states/mod.rs
@@ -13,14 +13,14 @@ pub mod notifications;
 
 use prelude::*;
 
-use crate::system::{System, input::InputEvent, Display};
+use crate::system::{System, input::InputEvent, Display, Host};
 
 /// All built in states must implement this trait to be renderable by the WM
 pub trait State: Default {
     /// To draw the state to the display
-    fn render(&mut self, system: &mut impl System, display: &mut impl Display) -> Option<Signal>;
+    fn render(&mut self, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal>;
     /// Allows the state to take control of inputs from the kernel
-    fn input(&mut self, system: &mut impl System, input: InputEvent) -> Option<Signal>;
+    fn input(&mut self, system: &mut System<impl Host>, input: InputEvent) -> Option<Signal>;
 }
 
 /// Marker trait for static states
@@ -29,11 +29,11 @@ pub trait StaticState: State {}
 /// This state only exists whilst its running, and is destroyed on exit
 pub trait ScopedState: State {
     /// Render a preview or Icon before launching the whole application
-    fn preview(&mut self, system: &mut impl System, display: &mut impl Display) -> Option<Signal>;
+    fn preview(&mut self, system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal>;
     /// Start 
-    fn start(&mut self, system: &mut impl System);
+    fn start(&mut self, system: &mut System<impl Host>);
     /// Is the application running yet?
-    fn is_running(&self, system: &mut impl System) -> bool;
+    fn is_running(&self, system: &mut System<impl Host>) -> bool;
     /// Stop
-    fn stop(&mut self, system: &mut impl System);
+    fn stop(&mut self, system: &mut System<impl Host>);
 }

--- a/kernel/src/application/states/mwatch.rs
+++ b/kernel/src/application/states/mwatch.rs
@@ -1,6 +1,6 @@
 use crate::application::states::prelude::*;
 use crate::system::input::InputEvent;
-use crate::system::{Display, System};
+use crate::system::{Display, System, Host};
 
 use embedded_graphics::image::{Image, ImageRaw};
 use embedded_graphics::mono_font::ascii::FONT_6X12;
@@ -19,7 +19,7 @@ impl Default for MWState {
 }
 
 impl State for MWState {
-    fn render(&mut self, _system: &mut impl System, display: &mut impl Display) -> Option<Signal> {
+    fn render(&mut self, _system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> {
         Image::new(
             &ImageRaw::<Rgb565, LittleEndian>::new(include_bytes!("../../../data/mwatch.raw"), 64),
             Point::new(32, 10),
@@ -56,7 +56,7 @@ impl State for MWState {
         None
     }
 
-    fn input(&mut self, _system: &mut impl System, input: InputEvent) -> Option<Signal> {
+    fn input(&mut self, _system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> {
         match input {
             InputEvent::Left => Some(Signal::Previous),
             InputEvent::Right => Some(Signal::Next),

--- a/kernel/src/application/states/uop.rs
+++ b/kernel/src/application/states/uop.rs
@@ -1,6 +1,6 @@
 //! Uop Logo state
 
-use crate::{application::states::prelude::*, system::{System, input::InputEvent, Display}};
+use crate::{application::states::prelude::*, system::{System, input::InputEvent, Display, Host}};
 
 use embedded_graphics::{image::{Image, ImageRaw}, pixelcolor::{Rgb565, raw::LittleEndian}, prelude::{Point, OriginDimensions}, Drawable};
 
@@ -15,7 +15,7 @@ impl Default for UopState {
 }
 
 impl State for UopState {
-    fn render(&mut self, _system: &mut impl System, display: &mut impl Display) -> Option<Signal> {
+    fn render(&mut self, _system: &mut System<impl Host>, display: &mut impl Display) -> Option<Signal> {
         let dsize = display.bounding_box().size;
         let image = ImageRaw::<Rgb565, LittleEndian>::new(include_bytes!("../../../data/uop.raw"), 48);
         let size = image.size();
@@ -27,7 +27,7 @@ impl State for UopState {
         None
     }
 
-    fn input(&mut self, _system: &mut impl System, input: InputEvent) -> Option<Signal> {
+    fn input(&mut self, _system: &mut System<impl Host>, input: InputEvent) -> Option<Signal> {
         match input {
             InputEvent::Left => Some(Signal::Previous),
             InputEvent::Right => Some(Signal::Next),

--- a/kernel/src/system/syscall.rs
+++ b/kernel/src/system/syscall.rs
@@ -8,7 +8,9 @@ use core::str::FromStr;
 
 use time::{Date, Time};
 
-use super::System;
+use crate::system::Clock;
+
+use super::{System, Host};
 
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -47,15 +49,15 @@ impl FromStr for Syscall {
 
 impl Syscall {
 
-    pub fn execute(self, system: &mut impl System) {
+    pub fn execute(self, system: &mut System<impl Host>) {
         match self {
             Syscall::Date(date) => {
                 info!("Setting the date to {:?}", date);
-                system.set_date(&date);
+                system.clock.set_date(&date);
             },
             Syscall::Time(time) => {
                 info!("Setting the time to {:?}", time);
-                system.set_time(&time);
+                system.clock.set_time(&time);
             },
         }
     }


### PR DESCRIPTION
- Replace the `System` super trait
- Add a `System` struct which is generic over `Host`
- Host has assoc types which allow custom fields to be passed into `System`, provided they implement certain traits
- This makes it easier to split code up on the `Host` implementation side, as they can all sorts of different types instead of one super type which implements the old super trait